### PR TITLE
🆕(site) Improve inline code block styling

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
   repository_dispatch:
-    types:
-      - sanity_deploy
 
 jobs:
   test-build-deploy:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Make code run through TTY
+exec >/dev/tty 2>&1
+
 npm run lint:staged

--- a/src/sass/components/_pre.scss
+++ b/src/sass/components/_pre.scss
@@ -55,9 +55,10 @@ pre {
 
 code:not([class]) {
   font-family: 'dm', monospace;
-  background: var(--pink);
+  background: var(--dark-grey);
   font-size: 0.8em;
-  padding: 0em 0.25em;
+  padding: 0.1em 0.25em;
+  border-radius: 1px;
 }
 
 .token.prolog,

--- a/src/sass/components/_type.scss
+++ b/src/sass/components/_type.scss
@@ -4,6 +4,7 @@
   --dark-black: #111;
   --black: hsl(225, 6%, 13%);
   --grey: hsl(225, 6%, 50%);
+  --dark-grey: hsl(225, 6%, 37%);
   --white: hsl(0, 0%, 84%);
   --red: hsl(345, 100%, 38%);
   --light-red: hsl(345, 100%, 68%);


### PR DESCRIPTION
* Previous code block styling looked too much like a link; made the background an accessible grey instead
* Also fixed husky `pre-commit` hook not outputting correctly