### PR TITLE
🐛(build) Fix pull request environments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
   repository_dispatch:
-    types:
-      - sanity_deploy
 
 jobs:
   test-build-deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   test-build:
     runs-on: ubuntu-latest
-    environment: production
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Pull requests aren't part of the "production" environment, so they shouldn't be treated as such