### PR TITLE
🆕(site) Add Mastadon link back

### DIFF
--- a/src/layouts/Donut.astro
+++ b/src/layouts/Donut.astro
@@ -20,6 +20,7 @@ const { title, summary } = Astro.props;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/fonts/dank-mono.css" />
+    <link rel="me" href="https://mas.to/@snugug" />
     {
       import.meta.env.MODE !== 'development' ? (
         <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
Trying out the toots, adding a link back to verify ownership of my site